### PR TITLE
Add left workspace panel with tabs to realtime assistant

### DIFF
--- a/frontend/app/realtime-assistant/page.tsx
+++ b/frontend/app/realtime-assistant/page.tsx
@@ -27,6 +27,32 @@ const STATUS_CARD_VARIANTS: Record<ShareStatus, string> = {
     "border-rose-500/60 bg-rose-500/10 text-rose-200 shadow-[0_10px_30px_-12px_rgba(244,63,94,0.55)]",
 };
 
+const DEFAULT_PYTHON_SNIPPET = `import time
+
+class AttentionVisualizer:
+    def __init__(self, tokens: list[str]):
+        self.tokens = tokens
+        self.weights = [[1 / len(tokens) for _ in tokens] for _ in tokens]
+
+    def step(self) -> None:
+        for row in self.weights:
+            decay = 0.72 + (time.time() % 0.08)
+            for index, weight in enumerate(row):
+                row[index] = max(0.01, weight * decay)
+
+    def summary(self) -> str:
+        return " | ".join(
+            f"{token}: {max(weights):.2f}"
+            for token, weights in zip(self.tokens, self.weights)
+        )
+
+if __name__ == "__main__":
+    visualizer = AttentionVisualizer(["The", "future", "is", "streaming"])
+    for _ in range(4):
+        visualizer.step()
+        print(visualizer.summary())
+`;
+
 type DomElementDigest = {
   selector: string;
   tag: string;
@@ -242,6 +268,12 @@ export default function RealtimeAssistantPage(): JSX.Element {
   const [lastSharedPreview, setLastSharedPreview] = useState<string | null>(
     null
   );
+  const [activeWorkspaceTab, setActiveWorkspaceTab] = useState<
+    "code" | "paper"
+  >("code");
+  const [pythonSnippet, setPythonSnippet] = useState<string>(
+    DEFAULT_PYTHON_SNIPPET
+  );
 
   useEffect(() => {
     return () => {
@@ -404,100 +436,192 @@ export default function RealtimeAssistantPage(): JSX.Element {
               </div>
             </header>
 
-          <section className="relative z-10 mt-10 grid gap-6 lg:grid-cols-[minmax(0,1.6fr)_minmax(0,1fr)]">
-            <RealtimeConversationPanel
-              onShareVisionFrame={() => shareUiContext({ silent: true })}
-              visionFrameIntervalMs={15000} // 15 seconds - adjust this value to change frequency
-            />
-
-            <div className="space-y-5 rounded-2xl border border-slate-800/60 bg-slate-900/75 p-6 shadow-[0_25px_50px_-20px_rgba(15,23,42,0.65)] backdrop-blur">
-              <Heading as="h2" size="4" className="font-heading text-slate-50">
-                Visual context sharing
-              </Heading>
-              <Text className="text-sm leading-relaxed text-slate-300">
-                Capture the visible UI so the assistant understands what you
-                see. Screenshots are automatically analyzed using AI vision and
-                sent before each conversation, giving the assistant full context
-                about your current workspace, applications, and tasks.
-              </Text>
-              {lastSharedPreview ? (
-                <figure className="overflow-hidden rounded-xl border border-slate-800/80 bg-slate-950/80 shadow-lg">
-                  <div className="relative">
-                    <div className="absolute inset-x-0 top-0 z-10 bg-gradient-to-b from-slate-950/70 via-slate-950/10 to-transparent px-4 py-3">
-                      <Text className="text-xs font-medium uppercase tracking-wide text-emerald-300">
-                        Latest shared view
-                      </Text>
-                      {lastSharedLabel ? (
-                        <Text className="text-[11px] text-slate-200/80">
-                          Captured at {lastSharedLabel}
-                        </Text>
-                      ) : null}
-                    </div>
-                    <img
-                      src={lastSharedPreview}
-                      alt="Latest screenshot shared with the assistant"
-                      className="max-h-72 w-full object-cover"
-                    />
-                  </div>
-                  <figcaption className="border-t border-slate-800/80 bg-slate-950/60 px-4 py-3 text-xs text-slate-400">
-                    This preview mirrors the exact screenshot transmitted to
-                    GPT-5 in the realtime session, helping you confirm the
-                    assistant sees the correct workspace.
-                  </figcaption>
-                </figure>
-              ) : null}
-              <div
-                className={`space-y-2 rounded-xl border px-4 py-3 transition-colors ${statusCardTone}`}
-              >
-                <Text className="text-sm font-medium">
-                  {shareMessage ?? "No context shared yet."}
-                </Text>
-                {lastSharedLabel ? (
-                  <Text className="text-xs uppercase tracking-wide text-slate-400">
-                    Last shared · {lastSharedLabel}
+          <section className="relative z-10 mt-10 grid gap-6 lg:grid-cols-[minmax(0,0.95fr)_minmax(0,1.15fr)]">
+            <div className="flex flex-col justify-between gap-6 rounded-2xl border border-slate-800/60 bg-slate-900/70 p-6 shadow-[0_25px_50px_-20px_rgba(15,118,110,0.45)] backdrop-blur">
+              <header className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+                <div>
+                  <p className="text-xs font-semibold uppercase tracking-[0.32em] text-emerald-300/80">
+                    Workspace tools
+                  </p>
+                  <Heading as="h2" size="4" className="mt-1 font-heading text-slate-50">
+                    Creative companion panel
+                  </Heading>
+                  <Text className="mt-2 text-sm text-slate-300">
+                    Swap between a Python scratchpad or dive into the “Attention
+                    Is All You Need” paper without leaving the assistant.
                   </Text>
+                </div>
+                <div className="inline-flex h-9 items-center gap-2 rounded-full border border-emerald-400/40 bg-emerald-400/10 px-4 text-xs font-semibold uppercase tracking-[0.28em] text-emerald-200">
+                  Live
+                </div>
+              </header>
+
+              <div>
+                <div className="flex gap-2 rounded-xl border border-slate-800/60 bg-slate-950/60 p-1">
+                  {[
+                    { id: "code" as const, label: "Python editor" },
+                    { id: "paper" as const, label: "Research paper" },
+                  ].map((tab) => {
+                    const isActive = activeWorkspaceTab === tab.id;
+                    return (
+                      <button
+                        key={tab.id}
+                        type="button"
+                        onClick={() => setActiveWorkspaceTab(tab.id)}
+                        className={`flex-1 rounded-lg px-3 py-2 text-sm font-medium transition ${
+                          isActive
+                            ? "bg-emerald-400 text-slate-950 shadow-[0_10px_30px_-20px_rgba(16,185,129,0.9)]"
+                            : "text-slate-300 hover:text-slate-100"
+                        }`}
+                      >
+                        {tab.label}
+                      </button>
+                    );
+                  })}
+                </div>
+
+                <div className="mt-5">
+                  {activeWorkspaceTab === "code" ? (
+                    <div className="space-y-4 rounded-xl border border-slate-800/70 bg-slate-950/70 p-5">
+                      <div className="flex flex-wrap items-center justify-between gap-3">
+                        <Text className="text-sm font-semibold text-emerald-200">
+                          Python scratchpad
+                        </Text>
+                        <span className="rounded-full border border-emerald-400/40 bg-emerald-400/10 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] text-emerald-200">
+                          Synced
+                        </span>
+                      </div>
+                      <textarea
+                        value={pythonSnippet}
+                        onChange={(event) => setPythonSnippet(event.target.value)}
+                        spellCheck={false}
+                        className="h-[26rem] w-full resize-none rounded-lg border border-slate-800/70 bg-slate-950/80 p-4 font-mono text-sm leading-relaxed text-emerald-100 shadow-inner focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-400/40"
+                        aria-label="Python code editor"
+                      />
+                      <Text className="text-xs text-slate-400">
+                        Draft quick utilities or calculations while collaborating with
+                        GPT-5. Code is kept locally in this tab for rapid iteration.
+                      </Text>
+                    </div>
+                  ) : (
+                    <div className="overflow-hidden rounded-xl border border-slate-800/70 bg-slate-950/70">
+                      <object
+                        data="https://arxiv.org/pdf/1706.03762.pdf#toolbar=0"
+                        type="application/pdf"
+                        className="h-[26rem] w-full"
+                      >
+                        <div className="p-6 text-sm text-slate-300">
+                          Your browser cannot display PDFs.
+                          <a
+                            href="https://arxiv.org/pdf/1706.03762.pdf"
+                            className="ml-2 text-emerald-300 underline"
+                          >
+                            Download the paper
+                          </a>
+                          .
+                        </div>
+                      </object>
+                    </div>
+                  )}
+                </div>
+              </div>
+            </div>
+
+            <div className="space-y-6">
+              <RealtimeConversationPanel
+                onShareVisionFrame={() => shareUiContext({ silent: true })}
+                visionFrameIntervalMs={15000} // 15 seconds - adjust this value to change frequency
+              />
+
+              <div className="space-y-5 rounded-2xl border border-slate-800/60 bg-slate-900/75 p-6 shadow-[0_25px_50px_-20px_rgba(15,23,42,0.65)] backdrop-blur">
+                <Heading as="h2" size="4" className="font-heading text-slate-50">
+                  Visual context sharing
+                </Heading>
+                <Text className="text-sm leading-relaxed text-slate-300">
+                  Capture the visible UI so the assistant understands what you
+                  see. Screenshots are automatically analyzed using AI vision and
+                  sent before each conversation, giving the assistant full context
+                  about your current workspace, applications, and tasks.
+                </Text>
+                {lastSharedPreview ? (
+                  <figure className="overflow-hidden rounded-xl border border-slate-800/80 bg-slate-950/80 shadow-lg">
+                    <div className="relative">
+                      <div className="absolute inset-x-0 top-0 z-10 bg-gradient-to-b from-slate-950/70 via-slate-950/10 to-transparent px-4 py-3">
+                        <Text className="text-xs font-medium uppercase tracking-wide text-emerald-300">
+                          Latest shared view
+                        </Text>
+                        {lastSharedLabel ? (
+                          <Text className="text-[11px] text-slate-200/80">
+                            Captured at {lastSharedLabel}
+                          </Text>
+                        ) : null}
+                      </div>
+                      <img
+                        src={lastSharedPreview}
+                        alt="Latest screenshot shared with the assistant"
+                        className="max-h-72 w-full object-cover"
+                      />
+                    </div>
+                    <figcaption className="border-t border-slate-800/80 bg-slate-950/60 px-4 py-3 text-xs text-slate-400">
+                      This preview mirrors the exact screenshot transmitted to
+                      GPT-5 in the realtime session, helping you confirm the
+                      assistant sees the correct workspace.
+                    </figcaption>
+                  </figure>
                 ) : null}
-              </div>
-              <div className="flex flex-col gap-3 sm:flex-row">
-                <Button
-                  onClick={() => {
-                    void shareUiContext().catch(() => undefined);
-                  }}
-                  disabled={shareStatus === "capturing"}
-                  className="flex-1 bg-emerald-400 text-slate-950 shadow-[0_16px_40px_-24px_rgba(16,185,129,0.9)] transition-transform hover:-translate-y-0.5 hover:bg-emerald-300 disabled:cursor-not-allowed disabled:opacity-80"
+                <div
+                  className={`space-y-2 rounded-xl border px-4 py-3 transition-colors ${statusCardTone}`}
                 >
-                  {shareStatus === "capturing"
-                    ? "Analyzing…"
-                    : "Share current view"}
-                </Button>
-                <Button
-                  variant="outline"
-                  onClick={() => {
-                    if (lastSharedAt) {
-                      setShareMessage(
-                        "The assistant has the latest analyzed context."
-                      );
-                      setShareStatus("shared");
-                      if (timeoutRef.current) {
-                        window.clearTimeout(timeoutRef.current);
+                  <Text className="text-sm font-medium">
+                    {shareMessage ?? "No context shared yet."}
+                  </Text>
+                  {lastSharedLabel ? (
+                    <Text className="text-xs uppercase tracking-wide text-slate-400">
+                      Last shared · {lastSharedLabel}
+                    </Text>
+                  ) : null}
+                </div>
+                <div className="flex flex-col gap-3 sm:flex-row">
+                  <Button
+                    onClick={() => {
+                      void shareUiContext().catch(() => undefined);
+                    }}
+                    disabled={shareStatus === "capturing"}
+                    className="flex-1 bg-emerald-400 text-slate-950 shadow-[0_16px_40px_-24px_rgba(16,185,129,0.9)] transition-transform hover:-translate-y-0.5 hover:bg-emerald-300 disabled:cursor-not-allowed disabled:opacity-80"
+                  >
+                    {shareStatus === "capturing"
+                      ? "Analyzing…"
+                      : "Share current view"}
+                  </Button>
+                  <Button
+                    variant="outline"
+                    onClick={() => {
+                      if (lastSharedAt) {
+                        setShareMessage(
+                          "The assistant has the latest analyzed context."
+                        );
+                        setShareStatus("shared");
+                        if (timeoutRef.current) {
+                          window.clearTimeout(timeoutRef.current);
+                        }
+                        timeoutRef.current = window.setTimeout(() => {
+                          setShareStatus("idle");
+                          setShareMessage(null);
+                        }, 2000);
                       }
-                      timeoutRef.current = window.setTimeout(() => {
-                        setShareStatus("idle");
-                        setShareMessage(null);
-                      }, 2000);
-                    }
-                  }}
-                  disabled={!lastSharedAt}
-                  className="flex-1 border-slate-700/70 bg-slate-900/40 text-slate-200 transition hover:bg-slate-800/70 hover:text-slate-50 disabled:border-slate-800/60 disabled:text-slate-500"
-                >
-                  Mark context as fresh
-                </Button>
+                    }}
+                    disabled={!lastSharedAt}
+                    className="flex-1 border-slate-700/70 bg-slate-900/40 text-slate-200 transition hover:bg-slate-800/70 hover:text-slate-50 disabled:border-slate-800/60 disabled:text-slate-500"
+                  >
+                    Mark context as fresh
+                  </Button>
+                </div>
+                <Text className="text-xs text-slate-400">
+                  Screenshots are analyzed using AI vision and context is shared
+                  with the assistant. Data remains in-memory for prototyping
+                  purposes and is not persisted.
+                </Text>
               </div>
-              <Text className="text-xs text-slate-400">
-                Screenshots are analyzed using AI vision and context is shared
-                with the assistant. Data remains in-memory for prototyping
-                purposes and is not persisted.
-              </Text>
             </div>
           </section>
         </div>


### PR DESCRIPTION
## Summary
- add a workspace tools column with tabbed navigation for a Python scratchpad and research paper viewer
- adjust the realtime assistant layout to include the new column alongside the conversation and context panels

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68daddb4df588327a89ae524ea6beb62