### PR TITLE
Refactor tutor mode into manager and agent APIs

### DIFF
--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -46,7 +46,14 @@ from app.schemas.realtime import (
 from app.schemas.journal import JournalEntryRequest, JournalEntryResponse
 from app.schemas.research import ResearchPaperSummary, ResearchSearchRequest
 from app.schemas.note import NoteCreateRequest, NoteCreateResponse
-from app.schemas.tutor import TutorModeRequest, TutorModeResponse
+from app.schemas.tutor import (
+    TutorAssessmentResponse,
+    TutorCoachResponse,
+    TutorCurriculumResponse,
+    TutorManagerResponse,
+    TutorModalitiesResponse,
+    TutorModeRequest,
+)
 from app.services.auth import Auth0Client, Auth0ClientError
 from app.services.emotion import EmotionAnalyzer
 from app.services.generative_ui import (
@@ -659,14 +666,55 @@ async def create_checkout_session(
     return PaymentCheckoutResponse(session_id=session.session_id, checkout_url=session.url)
 
 
-@router.post("/tutor/mode", response_model=TutorModeResponse, tags=["tutor"])
-async def create_tutor_mode_plan(
+@router.post("/tutor/mode", response_model=TutorManagerResponse, tags=["tutor"])
+@router.post("/tutor/manager", response_model=TutorManagerResponse, tags=["tutor"])
+async def tutor_manager_overview(
     payload: TutorModeRequest,
     tutor_service: TutorModeService = Depends(get_tutor_service),
-) -> TutorModeResponse:
-    """Create a BabyAGI-inspired tutoring plan powered by GPT-5."""
+) -> TutorManagerResponse:
+    """Return the tutor manager agent and its available hooks."""
 
-    return await tutor_service.generate_plan(payload)
+    return await tutor_service.manager_overview(payload)
+
+
+@router.post("/tutor/curriculum", response_model=TutorCurriculumResponse, tags=["tutor"])
+async def tutor_curriculum_plan(
+    payload: TutorModeRequest,
+    tutor_service: TutorModeService = Depends(get_tutor_service),
+) -> TutorCurriculumResponse:
+    """Return a staged curriculum assembled by the curriculum agent."""
+
+    return await tutor_service.curriculum_plan(payload)
+
+
+@router.post("/tutor/modalities", response_model=TutorModalitiesResponse, tags=["tutor"])
+async def tutor_modalities_plan(
+    payload: TutorModeRequest,
+    tutor_service: TutorModeService = Depends(get_tutor_service),
+) -> TutorModalitiesResponse:
+    """Return modality and resource recommendations from the modality agent."""
+
+    return await tutor_service.modalities_plan(payload)
+
+
+@router.post("/tutor/assessment", response_model=TutorAssessmentResponse, tags=["tutor"])
+async def tutor_assessment_plan(
+    payload: TutorModeRequest,
+    tutor_service: TutorModeService = Depends(get_tutor_service),
+) -> TutorAssessmentResponse:
+    """Return quizzes and answer keys from the assessment agent."""
+
+    return await tutor_service.assessment_plan(payload)
+
+
+@router.post("/tutor/coach", response_model=TutorCoachResponse, tags=["tutor"])
+async def tutor_coach_plan(
+    payload: TutorModeRequest,
+    tutor_service: TutorModeService = Depends(get_tutor_service),
+) -> TutorCoachResponse:
+    """Return diagnostic and completion guidance from the coach agent."""
+
+    return await tutor_service.coach_plan(payload)
 
 
 def _encode_event(payload: dict[str, object]) -> str:

--- a/backend/app/schemas/tutor.py
+++ b/backend/app/schemas/tutor.py
@@ -158,3 +158,71 @@ class TutorModeResponse(BaseModel):
     completion: TutorCompletionPlan
     conversation_manager: TutorConversationManager
     learning_stages: list[TutorLearningStage]
+
+
+class TutorAgentHook(BaseModel):
+    """Descriptor for a specialised tutor agent API."""
+
+    id: str = Field(description="Stable identifier used by the frontend")
+    name: str = Field(description="Human friendly agent name")
+    description: str = Field(description="What this agent is responsible for")
+    endpoint: str = Field(description="Relative API path to call the agent")
+
+
+class TutorManagerResponse(BaseModel):
+    """Manager agent response describing available hooks."""
+
+    model: str
+    generated_at: datetime
+    topic: str
+    learner_profile: str
+    objectives: list[str]
+    conversation_manager: TutorConversationManager
+    agent_hooks: list[TutorAgentHook]
+
+
+class TutorCurriculumResponse(BaseModel):
+    """Curriculum agent response with stages and concept breakdown."""
+
+    model: str
+    generated_at: datetime
+    topic: str
+    concept_breakdown: list[TutorConceptBreakdown]
+    learning_stages: list[TutorLearningStage]
+
+
+class TutorModalitiesResponse(BaseModel):
+    """Modalities agent response with recommended teaching approaches."""
+
+    model: str
+    generated_at: datetime
+    topic: str
+    objectives: list[str]
+    teaching_modalities: list[TutorTeachingModality]
+
+
+class TutorStageQuizSummary(BaseModel):
+    """Summary of a stage-level quiz for quick rendering."""
+
+    stage: str
+    quiz: TutorStageQuiz
+
+
+class TutorAssessmentResponse(BaseModel):
+    """Assessment agent response bundling quizzes and mastery checks."""
+
+    model: str
+    generated_at: datetime
+    topic: str
+    assessment: TutorAssessmentPlan
+    stage_quizzes: list[TutorStageQuizSummary]
+
+
+class TutorCoachResponse(BaseModel):
+    """Coach agent response with diagnostic and completion guidance."""
+
+    model: str
+    generated_at: datetime
+    topic: str
+    understanding: TutorUnderstandingPlan
+    completion: TutorCompletionPlan

--- a/frontend/app/tutor-mode/page.tsx
+++ b/frontend/app/tutor-mode/page.tsx
@@ -34,14 +34,14 @@ const AGENTS = [
     icon: Sparkles,
   },
   {
-    id: "strategist",
+    id: "curriculum",
     name: "Curriculum Strategist",
     tagline: "Designs the staged learning journey",
     accent: "from-sky-500/70 via-cyan-500/60 to-blue-500/70",
     icon: Compass,
   },
   {
-    id: "researcher",
+    id: "modalities",
     name: "Modality Researcher",
     tagline: "Curates resources and multi-modal explanations",
     accent: "from-violet-500/70 via-fuchsia-500/60 to-purple-500/70",
@@ -74,72 +74,120 @@ type TutorTeachingModalityKind =
   | "reading"
   | "other";
 
-type TutorModeResponse = {
+type TutorStageQuiz = {
+  prompt: string;
+  answer_key?: string | null;
+  remediation: string;
+};
+
+type TutorLearningStage = {
+  name: string;
+  focus: string;
+  objectives: string[];
+  prerequisites: string[];
+  pass_criteria: string[];
+  quiz: TutorStageQuiz;
+  on_success: string;
+  on_failure: string;
+};
+
+type TutorConceptBreakdown = {
+  concept: string;
+  llm_reasoning: string;
+  subtopics: string[];
+  real_world_connections: string[];
+  prerequisites: string[];
+  mastery_checks: string[];
+  remediation_plan: string;
+  advancement_cue: string;
+};
+
+type TutorTeachingModality = {
+  modality: TutorTeachingModalityKind;
+  description: string;
+  resources: string[];
+};
+
+type TutorAssessmentItem = {
+  prompt: string;
+  kind: "multiple_choice" | "short_answer" | "reflection" | "practical";
+  options?: string[] | null;
+  answer_key?: string | null;
+};
+
+type TutorAssessmentPlan = {
+  title: string;
+  format: string;
+  human_in_the_loop_notes: string;
+  items: TutorAssessmentItem[];
+};
+
+type TutorUnderstandingPlan = {
+  approach: string;
+  diagnostic_questions: string[];
+  signals_to_watch: string[];
+  beginner_flag_logic: string;
+  follow_up_questions: string[];
+  max_follow_up_iterations: number;
+  escalation_strategy: string;
+};
+
+type TutorCompletionPlan = {
+  mastery_indicators: string[];
+  wrap_up_plan: string;
+  follow_up_suggestions: string[];
+};
+
+type TutorManagerResponse = {
   model: string;
   generated_at: string;
   topic: string;
   learner_profile: string;
   objectives: string[];
-  understanding: {
-    approach: string;
-    diagnostic_questions: string[];
-    signals_to_watch: string[];
-    beginner_flag_logic: string;
-    follow_up_questions: string[];
-    max_follow_up_iterations: number;
-    escalation_strategy: string;
-  };
-  concept_breakdown: {
-    concept: string;
-    llm_reasoning: string;
-    subtopics: string[];
-    real_world_connections: string[];
-    prerequisites: string[];
-    mastery_checks: string[];
-    remediation_plan: string;
-    advancement_cue: string;
-  }[];
-  teaching_modalities: {
-    modality: TutorTeachingModalityKind;
-    description: string;
-    resources: string[];
-  }[];
-  assessment: {
-    title: string;
-    format: string;
-    human_in_the_loop_notes: string;
-    items: {
-      prompt: string;
-      kind: "multiple_choice" | "short_answer" | "reflection" | "practical";
-      options?: string[] | null;
-      answer_key?: string | null;
-    }[];
-  };
-  completion: {
-    mastery_indicators: string[];
-    wrap_up_plan: string;
-    follow_up_suggestions: string[];
-  };
   conversation_manager: {
     agent_role: string;
     topic_extraction_prompt: string;
     level_assessment_summary: string;
     containment_strategy: string;
   };
-  learning_stages: {
+  agent_hooks: {
+    id: AgentId;
     name: string;
-    focus: string;
-    objectives: string[];
-    prerequisites: string[];
-    pass_criteria: string[];
-    quiz: {
-      prompt: string;
-      answer_key?: string | null;
-      remediation: string;
-    };
-    on_success: string;
-    on_failure: string;
+    description: string;
+    endpoint: string;
   }[];
+};
+
+type TutorCurriculumResponse = {
+  model: string;
+  generated_at: string;
+  topic: string;
+  concept_breakdown: TutorConceptBreakdown[];
+  learning_stages: TutorLearningStage[];
+};
+
+type TutorModalitiesResponse = {
+  model: string;
+  generated_at: string;
+  topic: string;
+  objectives: string[];
+  teaching_modalities: TutorTeachingModality[];
+};
+
+type TutorAssessmentResponse = {
+  model: string;
+  generated_at: string;
+  topic: string;
+  assessment: TutorAssessmentPlan;
+  stage_quizzes: { stage: string; quiz: TutorStageQuiz }[];
+};
+
+type TutorCoachResponse = {
+  model: string;
+  generated_at: string;
+  topic: string;
+  understanding: TutorUnderstandingPlan;
+  completion: TutorCompletionPlan;
 };
 
 type AgentTask = {
@@ -166,43 +214,65 @@ function formatDate(value: string) {
   });
 }
 
-function buildAgentTasks(plan: TutorModeResponse): AgentTask[] {
-  const strategistTasks = plan.learning_stages.slice(0, 4).map((stage) => {
+type BuildAgentTaskInputs = {
+  manager?: TutorManagerResponse | null;
+  curriculum?: TutorCurriculumResponse | null;
+  modalities?: TutorModalitiesResponse | null;
+  assessment?: TutorAssessmentResponse | null;
+  coach?: TutorCoachResponse | null;
+};
+
+function buildAgentTasks({
+  manager,
+  curriculum,
+  modalities,
+  assessment,
+  coach,
+}: BuildAgentTaskInputs): AgentTask[] {
+  const strategistTasks = (curriculum?.learning_stages ?? []).slice(0, 4).map((stage) => {
     const criteriaPreview = stage.pass_criteria[0] ?? "keep the learner engaged";
     return `Architect stage "${stage.name}" focused on ${stage.focus}. Prioritise: ${criteriaPreview}.`;
   });
 
-  const modalityTasks = plan.teaching_modalities.slice(0, 4).map((modality) => {
+  const modalityTasks = (modalities?.teaching_modalities ?? []).slice(0, 4).map((modality) => {
     const resourcePreview = modality.resources[0]
       ? `Highlight ${modality.resources[0]}`
       : "Select supporting resources";
     return `Craft a ${modality.modality} experience: ${modality.description}. ${resourcePreview}.`;
   });
 
-  const assessmentTasks = [
-    `Design the "${plan.assessment.title}" assessment (${plan.assessment.format}).`,
-    plan.assessment.human_in_the_loop_notes,
-    ...plan.assessment.items.slice(0, 3).map((item, index) => {
-      const label = index + 1;
-      return `Draft item ${label}: ${item.prompt}`;
-    }),
-  ];
+  const assessmentTasks = assessment
+    ? [
+        `Design the "${assessment.assessment.title}" assessment (${assessment.assessment.format}).`,
+        assessment.assessment.human_in_the_loop_notes,
+        ...assessment.assessment.items.slice(0, 3).map((item, index) => {
+          const label = index + 1;
+          return `Draft item ${label}: ${item.prompt}`;
+        }),
+      ]
+    : [];
 
-  const coachTasks = [
-    `Kick off with: ${plan.understanding.approach}.`,
-    plan.understanding.diagnostic_questions[0]
-      ? `Use diagnostic question: ${plan.understanding.diagnostic_questions[0]}`
-      : "Prepare diagnostic follow-ups.",
-    `Watch for: ${plan.understanding.signals_to_watch.slice(0, 2).join(", ")}.`,
-    `Wrap-up plan: ${plan.completion.wrap_up_plan}.`,
-  ];
+  const coachTasks = coach
+    ? [
+        `Kick off with: ${coach.understanding.approach}.`,
+        coach.understanding.diagnostic_questions[0]
+          ? `Use diagnostic question: ${coach.understanding.diagnostic_questions[0]}`
+          : "Prepare diagnostic follow-ups.",
+        coach.understanding.signals_to_watch.length > 0
+          ? `Watch for: ${coach.understanding.signals_to_watch.slice(0, 2).join(", ")}.`
+          : "Define signals to watch during sessions.",
+        `Wrap-up plan: ${coach.completion.wrap_up_plan}.`,
+      ]
+    : [];
 
-  const managerTasks = [
-    plan.conversation_manager.agent_role,
-    `Topic extraction focus: ${plan.conversation_manager.topic_extraction_prompt}.`,
-    `Level insights: ${plan.conversation_manager.level_assessment_summary}.`,
-    `Containment strategy: ${plan.conversation_manager.containment_strategy}.`,
-  ];
+  const managerTasks = manager
+    ? [
+        manager.conversation_manager.agent_role,
+        `Topic extraction focus: ${manager.conversation_manager.topic_extraction_prompt}.`,
+        `Level insights: ${manager.conversation_manager.level_assessment_summary}.`,
+        `Containment strategy: ${manager.conversation_manager.containment_strategy}.`,
+      ]
+    : ["Coordinate the tutoring collective and route work to specialist agents."];
 
   return [
     {
@@ -211,32 +281,36 @@ function buildAgentTasks(plan: TutorModeResponse): AgentTask[] {
       tasks: managerTasks,
     },
     {
-      agentId: "strategist",
+      agentId: "curriculum",
       headline: "Design the learning journey",
-      tasks: strategistTasks.length > 0
-        ? strategistTasks
-        : ["Outline staged progression to cover the concept effectively."],
+      tasks:
+        strategistTasks.length > 0
+          ? strategistTasks
+          : ["Outline staged progression to cover the concept effectively."],
     },
     {
-      agentId: "researcher",
+      agentId: "modalities",
       headline: "Curate multi-modal experiences",
-      tasks: modalityTasks.length > 0
-        ? modalityTasks
-        : ["Select supporting resources and craft explanations across modalities."],
+      tasks:
+        modalityTasks.length > 0
+          ? modalityTasks
+          : ["Select supporting resources and craft explanations across modalities."],
     },
     {
       agentId: "assessment",
       headline: "Engineer mastery checks",
-      tasks: assessmentTasks.length > 0
-        ? assessmentTasks
-        : ["Build assessments that surface understanding and misconceptions."],
+      tasks:
+        assessmentTasks.length > 0
+          ? assessmentTasks
+          : ["Build assessments that surface understanding and misconceptions."],
     },
     {
       agentId: "coach",
       headline: "Coach the learner through the plan",
-      tasks: coachTasks.length > 0
-        ? coachTasks
-        : ["Monitor understanding signals and celebrate progress."],
+      tasks:
+        coachTasks.length > 0
+          ? coachTasks
+          : ["Monitor understanding signals and celebrate progress."],
     },
   ];
 }
@@ -256,8 +330,23 @@ export default function TutorModePage(): JSX.Element {
     },
   ]);
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [latestPlan, setLatestPlan] = useState<TutorModeResponse | null>(null);
+  const [managerOverview, setManagerOverview] = useState<TutorManagerResponse | null>(null);
+  const [curriculumPlan, setCurriculumPlan] = useState<TutorCurriculumResponse | null>(null);
+  const [modalitiesPlan, setModalitiesPlan] = useState<TutorModalitiesResponse | null>(null);
+  const [assessmentPlan, setAssessmentPlan] = useState<TutorAssessmentResponse | null>(null);
+  const [coachPlan, setCoachPlan] = useState<TutorCoachResponse | null>(null);
   const [assignmentBoard, setAssignmentBoard] = useState<AgentTask[]>([]);
+  const [quizState, setQuizState] = useState<
+    Record<
+      number,
+      {
+        selectedOption: string | null;
+        responseText: string;
+        status: "correct" | "incorrect" | "submitted" | null;
+        revealed: boolean;
+      }
+    >
+  >({});
   const chatViewportRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
@@ -265,16 +354,123 @@ export default function TutorModePage(): JSX.Element {
     chatViewportRef.current.scrollTop = chatViewportRef.current.scrollHeight;
   }, [messages]);
 
+  useEffect(() => {
+    if (!assessmentPlan) {
+      setQuizState({});
+      return;
+    }
+    const initial: Record<number, { selectedOption: string | null; responseText: string; status: "correct" | "incorrect" | "submitted" | null; revealed: boolean }> =
+      {};
+    assessmentPlan.assessment.items.forEach((_, index) => {
+      initial[index] = {
+        selectedOption: null,
+        responseText: "",
+        status: null,
+        revealed: false,
+      };
+    });
+    setQuizState(initial);
+  }, [assessmentPlan]);
+
   const formattedTimestamp = useMemo(() => {
-    if (!latestPlan) return null;
-    return formatDate(latestPlan.generated_at);
-  }, [latestPlan]);
+    if (!managerOverview) return null;
+    return formatDate(managerOverview.generated_at);
+  }, [managerOverview]);
 
   const handleKeyDown = useCallback((event: KeyboardEvent<HTMLTextAreaElement>) => {
     if (event.key === "Enter" && !event.shiftKey) {
       event.preventDefault();
       event.currentTarget.form?.requestSubmit();
     }
+  }, []);
+
+  const handleSelectOption = useCallback((index: number, option: string) => {
+    setQuizState((previous) => {
+      const current = previous[index] ?? {
+        selectedOption: null,
+        responseText: "",
+        status: null,
+        revealed: false,
+      };
+      return {
+        ...previous,
+        [index]: {
+          ...current,
+          selectedOption: option,
+          status: null,
+        },
+      };
+    });
+  }, []);
+
+  const handleResponseChange = useCallback((index: number, value: string) => {
+    setQuizState((previous) => {
+      const current = previous[index] ?? {
+        selectedOption: null,
+        responseText: "",
+        status: null,
+        revealed: false,
+      };
+      return {
+        ...previous,
+        [index]: {
+          ...current,
+          responseText: value,
+          status: null,
+        },
+      };
+    });
+  }, []);
+
+  const handleCheckAnswer = useCallback((index: number, item: TutorAssessmentItem) => {
+    setQuizState((previous) => {
+      const current = previous[index] ?? {
+        selectedOption: null,
+        responseText: "",
+        status: null,
+        revealed: false,
+      };
+      if (item.kind === "multiple_choice") {
+        if (!current.selectedOption) {
+          return previous;
+        }
+        const expected = item.answer_key?.trim().toLowerCase();
+        const actual = current.selectedOption.trim().toLowerCase();
+        const isCorrect = expected ? actual === expected : false;
+        return {
+          ...previous,
+          [index]: {
+            ...current,
+            status: isCorrect ? "correct" : "incorrect",
+          },
+        };
+      }
+      return {
+        ...previous,
+        [index]: {
+          ...current,
+          status: "submitted",
+        },
+      };
+    });
+  }, []);
+
+  const handleRevealAnswer = useCallback((index: number) => {
+    setQuizState((previous) => {
+      const current = previous[index] ?? {
+        selectedOption: null,
+        responseText: "",
+        status: null,
+        revealed: false,
+      };
+      return {
+        ...previous,
+        [index]: {
+          ...current,
+          revealed: true,
+        },
+      };
+    });
   }, []);
 
   const handleSubmit = useCallback(
@@ -302,53 +498,139 @@ export default function TutorModePage(): JSX.Element {
       setInputValue("");
       setIsSubmitting(true);
 
-      try {
-        const response = await fetch(`${API_BASE}/tutor/mode`, {
+      setManagerOverview(null);
+      setCurriculumPlan(null);
+      setModalitiesPlan(null);
+      setAssessmentPlan(null);
+      setCoachPlan(null);
+      setAssignmentBoard([]);
+      setQuizState({});
+
+      const requestPayload = {
+        topic: trimmed,
+        student_level: null,
+        goals: null,
+        preferred_modalities: null,
+        additional_context: "Generated from tutor-mode chat interface",
+      };
+      const requestBody = JSON.stringify(requestPayload);
+      const headers = { "Content-Type": "application/json" } as const;
+
+      const fetchJson = async <T,>(path: string): Promise<T> => {
+        const response = await fetch(`${API_BASE}${path}`, {
           method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            topic: trimmed,
-            student_level: null,
-            goals: null,
-            preferred_modalities: null,
-            additional_context: "Generated from tutor-mode chat interface",
-          }),
+          headers,
+          body: requestBody,
         });
-
         if (!response.ok) {
-          throw new Error("Unable to generate a tutor plan right now.");
+          throw new Error(`Request to ${path} failed with status ${response.status}`);
         }
+        return (await response.json()) as T;
+      };
 
-        const data: TutorModeResponse = await response.json();
-        const tasks = buildAgentTasks(data);
+      try {
+        const managerData = await fetchJson<TutorManagerResponse>("/tutor/mode");
+        setManagerOverview(managerData);
 
-        setLatestPlan(data);
-        setAssignmentBoard(tasks);
+        const agentPlaceholders = managerData.agent_hooks.map((hook) => ({
+          id: `${hook.id}-loading-${Date.now()}`,
+          role: hook.id as AgentId,
+          type: "loading" as const,
+        }));
 
         setMessages((previous) =>
           previous.flatMap((message) => {
             if (message.id !== placeholderId) {
               return [message];
             }
-
             const managerSummary: Message = {
               id: `manager-summary-${Date.now()}`,
               role: "manager",
               type: "text",
-              text: `Deploying ${tasks.length} specialist agents to help you master "${data.topic}". Here's how we're dividing the work:`,
+              text: `Deploying ${managerData.agent_hooks.length} specialist agents to help you master "${managerData.topic}". Here's how we're dividing the work:`,
             };
-
-            const taskMessages: Message[] = tasks.map((task, index) => ({
-              id: `${task.agentId}-${Date.now()}-${index}`,
-              role: task.agentId,
-              type: "tasks",
-              headline: task.headline,
-              tasks: task.tasks,
-            }));
-
-            return [managerSummary, ...taskMessages];
+            return [managerSummary, ...agentPlaceholders];
           })
         );
+
+        const [
+          curriculumResult,
+          modalitiesResult,
+          assessmentResult,
+          coachResult,
+        ] = await Promise.allSettled([
+          fetchJson<TutorCurriculumResponse>("/tutor/curriculum"),
+          fetchJson<TutorModalitiesResponse>("/tutor/modalities"),
+          fetchJson<TutorAssessmentResponse>("/tutor/assessment"),
+          fetchJson<TutorCoachResponse>("/tutor/coach"),
+        ]);
+
+        let curriculumData: TutorCurriculumResponse | null = null;
+        let modalitiesData: TutorModalitiesResponse | null = null;
+        let assessmentData: TutorAssessmentResponse | null = null;
+        let coachData: TutorCoachResponse | null = null;
+        const failedAgentNames: string[] = [];
+
+        const hookName = (id: AgentId) =>
+          managerData.agent_hooks.find((hook) => hook.id === id)?.name ?? id;
+
+        if (curriculumResult.status === "fulfilled") {
+          curriculumData = curriculumResult.value;
+          setCurriculumPlan(curriculumResult.value);
+        } else {
+          failedAgentNames.push(hookName("curriculum"));
+        }
+
+        if (modalitiesResult.status === "fulfilled") {
+          modalitiesData = modalitiesResult.value;
+          setModalitiesPlan(modalitiesResult.value);
+        } else {
+          failedAgentNames.push(hookName("modalities"));
+        }
+
+        if (assessmentResult.status === "fulfilled") {
+          assessmentData = assessmentResult.value;
+          setAssessmentPlan(assessmentResult.value);
+        } else {
+          failedAgentNames.push(hookName("assessment"));
+        }
+
+        if (coachResult.status === "fulfilled") {
+          coachData = coachResult.value;
+          setCoachPlan(coachResult.value);
+        } else {
+          failedAgentNames.push(hookName("coach"));
+        }
+
+        const tasks = buildAgentTasks({
+          manager: managerData,
+          curriculum: curriculumData,
+          modalities: modalitiesData,
+          assessment: assessmentData,
+          coach: coachData,
+        });
+        setAssignmentBoard(tasks);
+
+        setMessages((previous) => {
+          const withoutLoading = previous.filter((message) => message.type !== "loading");
+          const taskMessages: Message[] = tasks.map((task, index) => ({
+            id: `${task.agentId}-${Date.now()}-${index}`,
+            role: task.agentId,
+            type: "tasks",
+            headline: task.headline,
+            tasks: task.tasks,
+          }));
+          const nextMessages = [...withoutLoading, ...taskMessages];
+          if (failedAgentNames.length > 0) {
+            nextMessages.push({
+              id: `warning-${Date.now()}`,
+              role: "manager",
+              type: "text",
+              text: `Heads up: I couldn't reach the ${failedAgentNames.join(", ")} agent${failedAgentNames.length > 1 ? "s" : ""}. Check back shortly for their materials.`,
+            });
+          }
+          return nextMessages;
+        });
       } catch (error) {
         console.error("Tutor mode request failed", error);
         setMessages((previous) =>
@@ -585,30 +867,39 @@ export default function TutorModePage(): JSX.Element {
               )}
             </div>
 
-            {latestPlan && (
-              <div className="rounded-3xl border border-slate-900/70 bg-slate-950/60 p-6 shadow-xl shadow-slate-950/60">
-                <p className="text-xs uppercase tracking-[0.3em] text-slate-500">Latest GPT-5 intel</p>
-                <h2 className="mt-2 text-lg font-semibold text-white">Plan snapshot</h2>
+            <div className="rounded-3xl border border-slate-900/70 bg-slate-950/60 p-6 shadow-xl shadow-slate-950/60">
+              <p className="text-xs uppercase tracking-[0.3em] text-slate-500">Latest GPT-5 intel</p>
+              <h2 className="mt-2 text-lg font-semibold text-white">Manager snapshot</h2>
+              {managerOverview ? (
                 <div className="mt-4 space-y-4 text-sm text-slate-200">
                   <div>
                     <p className="text-xs uppercase text-slate-500">Topic</p>
-                    <p className="mt-1 text-base text-white">{latestPlan.topic}</p>
+                    <p className="mt-1 text-base text-white">{managerOverview.topic}</p>
                   </div>
                   <div>
                     <p className="text-xs uppercase text-slate-500">Learner profile</p>
-                    <p className="mt-1 text-slate-300">{latestPlan.learner_profile}</p>
+                    <p className="mt-1 text-slate-300">{managerOverview.learner_profile}</p>
                   </div>
                   <div>
                     <p className="text-xs uppercase text-slate-500">Objectives</p>
                     <ul className="mt-2 space-y-1 text-slate-300">
-                      {latestPlan.objectives.slice(0, 4).map((objective, index) => (
+                      {managerOverview.objectives.slice(0, 4).map((objective, index) => (
                         <li key={index}>{objective}</li>
                       ))}
                     </ul>
                   </div>
                   <div>
+                    <p className="text-xs uppercase text-slate-500">Manager directives</p>
+                    <ul className="mt-2 space-y-1 text-slate-300">
+                      <li>{managerOverview.conversation_manager.agent_role}</li>
+                      <li>{managerOverview.conversation_manager.topic_extraction_prompt}</li>
+                      <li>{managerOverview.conversation_manager.level_assessment_summary}</li>
+                      <li>{managerOverview.conversation_manager.containment_strategy}</li>
+                    </ul>
+                  </div>
+                  <div>
                     <p className="text-xs uppercase text-slate-500">Model</p>
-                    <p className="mt-1 text-slate-300">{latestPlan.model}</p>
+                    <p className="mt-1 text-slate-300">{managerOverview.model}</p>
                   </div>
                   {formattedTimestamp && (
                     <div>
@@ -616,9 +907,374 @@ export default function TutorModePage(): JSX.Element {
                       <p className="mt-1 text-slate-300">{formattedTimestamp}</p>
                     </div>
                   )}
+                  <div>
+                    <p className="text-xs uppercase text-slate-500">Agent hooks</p>
+                    <ul className="mt-2 space-y-2">
+                      {managerOverview.agent_hooks.map((hook) => (
+                        <li
+                          key={hook.id}
+                          className="rounded-2xl border border-slate-900/60 bg-slate-900/60 p-3 text-slate-200"
+                        >
+                          <p className="text-sm font-semibold text-white">{hook.name}</p>
+                          <p className="text-xs text-slate-400">{hook.description}</p>
+                          <p className="mt-1 text-[11px] uppercase tracking-[0.2em] text-emerald-400">
+                            {hook.endpoint}
+                          </p>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
                 </div>
-              </div>
-            )}
+              ) : (
+                <div className="mt-4 rounded-2xl border border-slate-900/60 bg-slate-900/50 p-5 text-sm text-slate-400">
+                  Ask the manager to plan a session to populate this snapshot.
+                </div>
+              )}
+            </div>
+
+            <div className="rounded-3xl border border-slate-900/70 bg-slate-950/60 p-6 shadow-xl shadow-slate-950/60">
+              <p className="text-xs uppercase tracking-[0.3em] text-slate-500">Curriculum blueprint</p>
+              <h2 className="mt-2 text-lg font-semibold text-white">Learning path</h2>
+              {curriculumPlan ? (
+                <div className="mt-4 space-y-5 text-sm text-slate-200">
+                  <div>
+                    <p className="text-xs uppercase text-slate-500">Stages</p>
+                    <div className="mt-3 space-y-3">
+                      {curriculumPlan.learning_stages.map((stage, index) => (
+                        <div
+                          key={stage.name}
+                          className="rounded-2xl border border-slate-900/60 bg-slate-900/60 p-4"
+                        >
+                          <div className="flex flex-wrap items-center justify-between gap-2">
+                            <p className="text-sm font-semibold text-white">
+                              Stage {index + 1}: {stage.name}
+                            </p>
+                            <span className="text-xs uppercase tracking-[0.2em] text-emerald-400">
+                              {stage.focus}
+                            </span>
+                          </div>
+                          <p className="mt-2 text-slate-300">
+                            {stage.objectives[0] ?? "Focus on building intuition for this topic."}
+                          </p>
+                          <div className="mt-3 grid gap-3 sm:grid-cols-2">
+                            <div>
+                              <p className="text-xs uppercase text-slate-500">Prerequisites</p>
+                              <ul className="mt-2 space-y-1 text-slate-300">
+                                {(stage.prerequisites.length > 0 ? stage.prerequisites : ["None specified"]).map(
+                                  (item, idx) => (
+                                    <li key={idx}>{item}</li>
+                                  )
+                                )}
+                              </ul>
+                            </div>
+                            <div>
+                              <p className="text-xs uppercase text-slate-500">Pass criteria</p>
+                              <ul className="mt-2 space-y-1 text-slate-300">
+                                {(stage.pass_criteria.length > 0
+                                  ? stage.pass_criteria
+                                  : ["Demonstrate understanding before advancing."]).map((item, idx) => (
+                                  <li key={idx}>{item}</li>
+                                ))}
+                              </ul>
+                            </div>
+                          </div>
+                          <div className="mt-3 rounded-xl border border-slate-800/60 bg-slate-900/50 p-3">
+                            <p className="text-xs uppercase text-slate-500">Quiz prompt</p>
+                            <p className="mt-1 text-slate-200">{stage.quiz.prompt}</p>
+                            <p className="mt-2 text-xs text-slate-500">Remediation: {stage.quiz.remediation}</p>
+                          </div>
+                          <div className="mt-3 text-xs text-slate-500">
+                            <p>On success: {stage.on_success}</p>
+                            <p className="mt-1">On failure: {stage.on_failure}</p>
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                  <div>
+                    <p className="text-xs uppercase text-slate-500">Key concepts</p>
+                    <div className="mt-3 space-y-3">
+                      {curriculumPlan.concept_breakdown.slice(0, 3).map((concept) => (
+                        <div
+                          key={concept.concept}
+                          className="rounded-2xl border border-slate-900/60 bg-slate-900/60 p-4"
+                        >
+                          <p className="text-sm font-semibold text-white">{concept.concept}</p>
+                          <p className="mt-2 text-slate-300">{concept.llm_reasoning}</p>
+                          <div className="mt-3 grid gap-3 sm:grid-cols-3">
+                            <div>
+                              <p className="text-xs uppercase text-slate-500">Subtopics</p>
+                              <ul className="mt-2 space-y-1 text-slate-300">
+                                {(concept.subtopics.length > 0 ? concept.subtopics : ["Introduce fundamentals."]).map(
+                                  (item, idx) => (
+                                    <li key={idx}>{item}</li>
+                                  )
+                                )}
+                              </ul>
+                            </div>
+                            <div>
+                              <p className="text-xs uppercase text-slate-500">Connections</p>
+                              <ul className="mt-2 space-y-1 text-slate-300">
+                                {(concept.real_world_connections.length > 0
+                                  ? concept.real_world_connections
+                                  : ["Relate to a real-world scenario."]).map((item, idx) => (
+                                  <li key={idx}>{item}</li>
+                                ))}
+                              </ul>
+                            </div>
+                            <div>
+                              <p className="text-xs uppercase text-slate-500">Mastery checks</p>
+                              <ul className="mt-2 space-y-1 text-slate-300">
+                                {(concept.mastery_checks.length > 0
+                                  ? concept.mastery_checks
+                                  : ["Ask the learner to explain in their own words."]).map((item, idx) => (
+                                  <li key={idx}>{item}</li>
+                                ))}
+                              </ul>
+                            </div>
+                          </div>
+                        </div>
+                      ))}
+                      {curriculumPlan.concept_breakdown.length > 3 && (
+                        <p className="text-xs text-slate-500">
+                          Additional concepts are available through the curriculum API endpoint.
+                        </p>
+                      )}
+                    </div>
+                  </div>
+                </div>
+              ) : (
+                <div className="mt-4 rounded-2xl border border-slate-900/60 bg-slate-900/50 p-5 text-sm text-slate-400">
+                  The curriculum strategist will populate staged learning materials once you launch a tutoring request.
+                </div>
+              )}
+            </div>
+
+            <div className="rounded-3xl border border-slate-900/70 bg-slate-950/60 p-6 shadow-xl shadow-slate-950/60">
+              <p className="text-xs uppercase tracking-[0.3em] text-slate-500">Modality lab</p>
+              <h2 className="mt-2 text-lg font-semibold text-white">Teaching approaches</h2>
+              {modalitiesPlan ? (
+                <div className="mt-4 space-y-3 text-sm text-slate-200">
+                  {modalitiesPlan.teaching_modalities.map((modality) => (
+                    <div
+                      key={`${modality.modality}-${modality.description.slice(0, 12)}`}
+                      className="rounded-2xl border border-slate-900/60 bg-slate-900/60 p-4"
+                    >
+                      <div className="flex items-center justify-between gap-3">
+                        <p className="text-sm font-semibold text-white capitalize">{modality.modality}</p>
+                        <span className="text-xs uppercase tracking-[0.2em] text-emerald-400">
+                          {modalitiesPlan.topic}
+                        </span>
+                      </div>
+                      <p className="mt-2 text-slate-300">{modality.description}</p>
+                      {modality.resources.length > 0 && (
+                        <div className="mt-3">
+                          <p className="text-xs uppercase text-slate-500">Suggested resources</p>
+                          <ul className="mt-2 space-y-1 text-slate-300">
+                            {modality.resources.map((resource, index) => (
+                              <li key={index}>{resource}</li>
+                            ))}
+                          </ul>
+                        </div>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <div className="mt-4 rounded-2xl border border-slate-900/60 bg-slate-900/50 p-5 text-sm text-slate-400">
+                  The modality researcher shares resources here once you brief the collective.
+                </div>
+              )}
+            </div>
+
+            <div className="rounded-3xl border border-slate-900/70 bg-slate-950/60 p-6 shadow-xl shadow-slate-950/60">
+              <p className="text-xs uppercase tracking-[0.3em] text-slate-500">Assessment studio</p>
+              <h2 className="mt-2 text-lg font-semibold text-white">Take the quiz</h2>
+              {assessmentPlan ? (
+                <div className="mt-4 space-y-5 text-sm text-slate-200">
+                  <div className="rounded-2xl border border-slate-900/60 bg-slate-900/60 p-4">
+                    <p className="text-sm font-semibold text-white">{assessmentPlan.assessment.title}</p>
+                    <p className="mt-1 text-xs uppercase tracking-[0.2em] text-slate-500">
+                      {assessmentPlan.assessment.format}
+                    </p>
+                    <p className="mt-2 text-slate-300">
+                      {assessmentPlan.assessment.human_in_the_loop_notes}
+                    </p>
+                  </div>
+                  <div className="space-y-4">
+                    {assessmentPlan.assessment.items.map((item, index) => {
+                      const state = quizState[index];
+                      const status = state?.status ?? null;
+                      const reveal = state?.revealed ?? false;
+                      const disableCheck =
+                        item.kind === "multiple_choice" && !(state?.selectedOption && state.selectedOption.length > 0);
+                      return (
+                        <div
+                          key={`${item.prompt}-${index}`}
+                          className="rounded-2xl border border-slate-900/60 bg-slate-900/60 p-4"
+                        >
+                          <div className="flex items-center justify-between gap-3">
+                            <p className="text-sm font-semibold text-white">
+                              Question {index + 1}: {item.kind.replace("_", " ")}
+                            </p>
+                            {status === "correct" && (
+                              <span className="text-xs font-semibold uppercase tracking-[0.2em] text-emerald-400">
+                                Correct
+                              </span>
+                            )}
+                            {status === "incorrect" && (
+                              <span className="text-xs font-semibold uppercase tracking-[0.2em] text-rose-400">
+                                Try again
+                              </span>
+                            )}
+                            {status === "submitted" && (
+                              <span className="text-xs font-semibold uppercase tracking-[0.2em] text-amber-300">
+                                Submitted
+                              </span>
+                            )}
+                          </div>
+                          <p className="mt-2 text-slate-300">{item.prompt}</p>
+                          {item.options && item.options.length > 0 ? (
+                            <div className="mt-4 space-y-2">
+                              {item.options.map((option, optionIndex) => {
+                                const isSelected = state?.selectedOption === option;
+                                return (
+                                  <button
+                                    key={optionIndex}
+                                    type="button"
+                                    onClick={() => handleSelectOption(index, option)}
+                                    className={cn(
+                                      "w-full rounded-xl border px-3 py-2 text-left text-sm transition",
+                                      isSelected
+                                        ? "border-emerald-400/80 bg-emerald-500/10 text-emerald-200"
+                                        : "border-slate-800/80 bg-slate-900/40 text-slate-200 hover:border-emerald-400/40"
+                                    )}
+                                  >
+                                    {option}
+                                  </button>
+                                );
+                              })}
+                            </div>
+                          ) : (
+                            <textarea
+                              value={state?.responseText ?? ""}
+                              onChange={(event) => handleResponseChange(index, event.target.value)}
+                              rows={3}
+                              placeholder="Type your response here…"
+                              className="mt-4 w-full rounded-xl border border-slate-800/70 bg-slate-950/60 p-3 text-sm text-slate-200 placeholder:text-slate-500 focus:border-emerald-400/60 focus:outline-none"
+                            />
+                          )}
+                          <div className="mt-4 flex flex-wrap items-center gap-3">
+                            <Button
+                              type="button"
+                              onClick={() => handleCheckAnswer(index, item)}
+                              disabled={disableCheck}
+                              className="bg-emerald-500 text-slate-950 hover:bg-emerald-400 disabled:cursor-not-allowed disabled:bg-emerald-500/50"
+                            >
+                              Check answer
+                            </Button>
+                            <Button
+                              type="button"
+                              variant="outline"
+                              onClick={() => handleRevealAnswer(index)}
+                              className="border-emerald-500/40 text-emerald-300 hover:border-emerald-400 hover:text-emerald-200"
+                            >
+                              {reveal ? "Hide answer" : "Reveal answer"}
+                            </Button>
+                          </div>
+                          {reveal && (
+                            <div className="mt-3 rounded-xl border border-slate-800/60 bg-slate-900/50 p-3 text-sm text-slate-200">
+                              <p className="text-xs uppercase tracking-[0.2em] text-slate-500">Answer key</p>
+                              <p className="mt-1 text-slate-200">
+                                {item.answer_key ?? "The facilitator will review this response manually."}
+                              </p>
+                            </div>
+                          )}
+                        </div>
+                      );
+                    })}
+                  </div>
+                  {assessmentPlan.stage_quizzes.length > 0 && (
+                    <div className="rounded-2xl border border-slate-900/60 bg-slate-900/60 p-4">
+                      <p className="text-sm font-semibold text-white">Stage-level quizzes</p>
+                      <ul className="mt-3 space-y-3 text-slate-200">
+                        {assessmentPlan.stage_quizzes.map((quiz) => (
+                          <li
+                            key={quiz.stage}
+                            className="rounded-xl border border-slate-800/60 bg-slate-900/50 p-3"
+                          >
+                            <p className="text-xs uppercase tracking-[0.2em] text-emerald-400">{quiz.stage}</p>
+                            <p className="mt-1 text-slate-200">{quiz.quiz.prompt}</p>
+                            {quiz.quiz.answer_key && (
+                              <p className="mt-2 text-xs text-slate-500">Answer key: {quiz.quiz.answer_key}</p>
+                            )}
+                            <p className="mt-2 text-xs text-slate-500">Remediation: {quiz.quiz.remediation}</p>
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  )}
+                </div>
+              ) : (
+                <div className="mt-4 rounded-2xl border border-slate-900/60 bg-slate-900/50 p-5 text-sm text-slate-400">
+                  Launch a tutoring request to receive quizzes and answer keys from the assessment architect.
+                </div>
+              )}
+            </div>
+
+            <div className="rounded-3xl border border-slate-900/70 bg-slate-950/60 p-6 shadow-xl shadow-slate-950/60">
+              <p className="text-xs uppercase tracking-[0.3em] text-slate-500">Progress coaching</p>
+              <h2 className="mt-2 text-lg font-semibold text-white">Understanding signals</h2>
+              {coachPlan ? (
+                <div className="mt-4 space-y-4 text-sm text-slate-200">
+                  <div>
+                    <p className="text-xs uppercase text-slate-500">Approach</p>
+                    <p className="mt-1 text-slate-300">{coachPlan.understanding.approach}</p>
+                  </div>
+                  <div>
+                    <p className="text-xs uppercase text-slate-500">Diagnostic questions</p>
+                    <ul className="mt-2 space-y-1 text-slate-300">
+                      {coachPlan.understanding.diagnostic_questions.map((question, index) => (
+                        <li key={index}>{question}</li>
+                      ))}
+                    </ul>
+                  </div>
+                  <div>
+                    <p className="text-xs uppercase text-slate-500">Signals to watch</p>
+                    <ul className="mt-2 space-y-1 text-slate-300">
+                      {coachPlan.understanding.signals_to_watch.map((signal, index) => (
+                        <li key={index}>{signal}</li>
+                      ))}
+                    </ul>
+                  </div>
+                  <div>
+                    <p className="text-xs uppercase text-slate-500">Escalation strategy</p>
+                    <p className="mt-1 text-slate-300">{coachPlan.understanding.escalation_strategy}</p>
+                  </div>
+                  <div>
+                    <p className="text-xs uppercase text-slate-500">Completion plan</p>
+                    <ul className="mt-2 space-y-1 text-slate-300">
+                      <li>Wrap up: {coachPlan.completion.wrap_up_plan}</li>
+                      {coachPlan.completion.mastery_indicators.map((indicator, index) => (
+                        <li key={index}>Indicator: {indicator}</li>
+                      ))}
+                    </ul>
+                  </div>
+                  <div>
+                    <p className="text-xs uppercase text-slate-500">Follow-up suggestions</p>
+                    <ul className="mt-2 space-y-1 text-slate-300">
+                      {coachPlan.completion.follow_up_suggestions.map((suggestion, index) => (
+                        <li key={index}>{suggestion}</li>
+                      ))}
+                    </ul>
+                  </div>
+                </div>
+              ) : (
+                <div className="mt-4 rounded-2xl border border-slate-900/60 bg-slate-900/50 p-5 text-sm text-slate-400">
+                  The progress coach will share diagnostic and celebration tips after the manager assembles a plan.
+                </div>
+              )}
+            </div>
           </aside>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add dedicated tutor manager, curriculum, modality, assessment, and coach response models and routes
- extend the tutor mode service with helper methods that power each agent endpoint while keeping the offline fallback
- refresh the tutor mode page to orchestrate the new APIs, show agent outputs, and add an interactive assessment experience

## Testing
- poetry run pytest *(fails: ModuleNotFoundError: No module named 'app')*
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dae0a43f2c8327b86a61d557b16ee4