### PR TITLE
Refactor tutor mode into multi-agent architecture

### DIFF
--- a/backend/tests/test_tutor.py
+++ b/backend/tests/test_tutor.py
@@ -3,41 +3,78 @@ from fastapi.testclient import TestClient
 from app.main import app
 
 
-def test_tutor_mode_offline_plan_structure() -> None:
-    """Tutor mode returns a rich plan even without an OpenAI API key."""
+PAYLOAD = {
+    "topic": "Neural Networks",
+    "student_level": "Beginner programmer transitioning into ML",
+    "goals": ["Understand core building blocks", "Implement a simple network"],
+    "preferred_modalities": ["visual", "interactive"],
+}
 
-    payload = {
-        "topic": "Neural Networks",
-        "student_level": "Beginner programmer transitioning into ML",
-        "goals": ["Understand core building blocks", "Implement a simple network"],
-        "preferred_modalities": ["visual", "interactive"],
-    }
+
+def test_tutor_manager_dispatches_agents() -> None:
+    """Tutor mode manager should return a roster of agent outputs."""
 
     with TestClient(app) as client:
-        response = client.post("/api/v1/tutor/mode", json=payload)
+        response = client.post("/api/v1/tutor/mode", json=PAYLOAD)
 
     assert response.status_code == 200
     data = response.json()
 
     assert data["model"] == "gpt-5"
-    assert data["topic"] == payload["topic"]
-    assert data["learner_profile"]
-    assert data["objectives"]
+    assert data["topic"] == PAYLOAD["topic"]
+    assert "GPT-5 Tutor Manager" in data["manager"]["name"]
+    assert len(data["manager"]["priorities"]) >= 3
 
-    understanding = data["understanding"]
-    assert understanding["diagnostic_questions"], "Expected diagnostic questions in plan"
+    agent_ids = {agent["id"] for agent in data["agents"]}
+    assert agent_ids == {"curriculum", "assessment", "practice", "coach"}
 
-    concepts = data["concept_breakdown"]
-    assert isinstance(concepts, list) and len(concepts) >= 1
-    assert concepts[0]["llm_reasoning"]
+    for agent in data["agents"]:
+        assert agent["status"] == "completed"
+        assert agent["payload"], f"Expected payload for agent {agent['id']}"
 
-    modalities = data["teaching_modalities"]
-    assert {modality["modality"] for modality in modalities} >= {"visual", "interactive", "verbal"}
 
-    assessment = data["assessment"]
-    assert assessment["human_in_the_loop_notes"]
-    assert any(item["kind"] == "practical" for item in assessment["items"])
+def test_curriculum_agent_sessions_are_structured() -> None:
+    """Curriculum agent should return multiple staged sessions."""
 
-    completion = data["completion"]
-    assert completion["mastery_indicators"]
-    assert completion["follow_up_suggestions"]
+    with TestClient(app) as client:
+        response = client.post("/api/v1/tutor/curriculum", json=PAYLOAD)
+
+    assert response.status_code == 200
+    data = response.json()
+
+    assert data["topic"] == PAYLOAD["topic"]
+    assert data["summary"]
+    assert len(data["sessions"]) >= 3
+    assert data["sessions"][0]["objectives"]
+
+
+def test_assessment_agent_includes_answer_key() -> None:
+    """Assessment agent provides graded questions with answers."""
+
+    with TestClient(app) as client:
+        response = client.post("/api/v1/tutor/assessment", json=PAYLOAD)
+
+    assert response.status_code == 200
+    data = response.json()
+
+    assert data["title"].lower().startswith(PAYLOAD["topic"].split()[0].lower())
+    assert data["questions"], "Expected assessment questions"
+    assert all(question["answer"] for question in data["questions"])
+
+
+def test_practice_and_coach_agents_have_guidance() -> None:
+    """Practice and coaching agents offer actionable steps."""
+
+    with TestClient(app) as client:
+        practice_response = client.post("/api/v1/tutor/practice", json=PAYLOAD)
+        coach_response = client.post("/api/v1/tutor/coach", json=PAYLOAD)
+
+    assert practice_response.status_code == 200
+    practice = practice_response.json()
+    assert practice["warmups"]
+    assert practice["sprints"]
+
+    assert coach_response.status_code == 200
+    coach = coach_response.json()
+    assert coach["onboarding_message"]
+    assert len(coach["check_ins"]) >= 3


### PR DESCRIPTION
## Summary
- refactor tutor schemas into multi-agent payloads and add dedicated services for curriculum, assessment, practice, and coaching orchestration
- expose new tutor endpoints and dependencies that dispatch the manager and individual agents
- refresh the tutor-mode UI to surface agent outputs with interactive assessments and update backend tests for the new contract

## Testing
- PYTHONPATH=. poetry run pytest tests/test_tutor.py
- npm run lint


------
https://chatgpt.com/codex/tasks/task_e_68dae0a43f2c8327b86a61d557b16ee4